### PR TITLE
Prefixing attributes with '@' symbol

### DIFF
--- a/XMLReader.m
+++ b/XMLReader.m
@@ -151,9 +151,14 @@ NSString *const kXMLReaderTextNodeKey = @"text";
     // Get the dictionary for the current level in the stack
     NSMutableDictionary *parentDict = [dictionaryStack lastObject];
     
-    // Create the child dictionary for the new element, and initialize it with the attributes
+    // Create the child dictionary for the new element
     NSMutableDictionary *childDict = [NSMutableDictionary dictionary];
-    [childDict addEntriesFromDictionary:attributeDict];
+
+    // Initialize child dictionary with the attributes, prefixed with '@'
+    for (NSString *key in attributeDict) {
+        [childDict setValue:[attributeDict objectForKey:key]
+                     forKey:[NSString stringWithFormat:@"@%@", key]];
+    }
     
     // If there's already an item for this key, it means we need to create an array
     id existingValue = [parentDict objectForKey:elementName];


### PR DESCRIPTION
In order to prevent overwriting of nodes with attribute values (or vice versa!), I propose prefixing attribute keys with the '@' symbol:

```<node foo="bar">
  <foo>baz</foo>
</node>

``````

```foo``` is ambiguous, as it would have two values.

Now we will have a dictionary with keys ```@foo``` for the attribute and ```foo``` for the node.
``````
