### PR TITLE
removing warning since xcode 4.2 and ios 5.0

### DIFF
--- a/NSData+XMLReader.h
+++ b/NSData+XMLReader.h
@@ -9,7 +9,7 @@
 @interface NSData (NSData_XMLReader)
 
 
--(NSDictionary *) dictionaryFromXML:(NSError**) error;
-+(NSDictionary *) dictionaryFromXML:(NSData*) xml error:(NSError**) error;
+-(NSDictionary *) dictionaryFromXML:(NSError *__autoreleasing *) error;
++(NSDictionary *) dictionaryFromXML:(NSData*) xml error:(NSError *__autoreleasing *) error;
 
 @end

--- a/NSData+XMLReader.h
+++ b/NSData+XMLReader.h
@@ -1,0 +1,15 @@
+//
+//  NSData+XMLReader.h
+
+//  Created by Fabien Di Tore on 05.08.11.
+
+
+#import <Foundation/Foundation.h>
+
+@interface NSData (NSData_XMLReader)
+
+
+-(NSDictionary *) dictionaryFromXML:(NSError**) error;
++(NSDictionary *) dictionaryFromXML:(NSData*) xml error:(NSError**) error;
+
+@end

--- a/NSData+XMLReader.m
+++ b/NSData+XMLReader.m
@@ -1,0 +1,21 @@
+//
+//  NSData+XMLReader.m
+
+//  Created by Fabien Di Tore on 05.08.11.
+
+
+#import "NSData+XMLReader.h"
+#import "XMLReader.h"
+@implementation NSData (NSData_XMLReader)
+
+-(NSDictionary *) dictionaryFromXML:(NSError**) error{
+	return [NSData dictionaryFromXML:self error:error];
+	
+}
+
++(NSDictionary *) dictionaryFromXML:(NSData*) xml error:(NSError**) error{
+	
+	return [XMLReader dictionaryForXMLData:xml error:error];
+}
+
+@end

--- a/NSData+XMLReader.m
+++ b/NSData+XMLReader.m
@@ -8,12 +8,13 @@
 #import "XMLReader.h"
 @implementation NSData (NSData_XMLReader)
 
--(NSDictionary *) dictionaryFromXML:(NSError**) error{
+-(NSDictionary *) dictionaryFromXML:(NSError *__autoreleasing *) error
+{
 	return [NSData dictionaryFromXML:self error:error];
 	
 }
 
-+(NSDictionary *) dictionaryFromXML:(NSData*) xml error:(NSError**) error{
++(NSDictionary *) dictionaryFromXML:(NSData*) xml error:(NSError *__autoreleasing *) error{
 	
 	return [XMLReader dictionaryForXMLData:xml error:error];
 }

--- a/NSString+XMLReader.h
+++ b/NSString+XMLReader.h
@@ -1,0 +1,14 @@
+//
+//  NSString+XMLReader.h
+//
+//  Created by Fabien Di Tore on 05.08.11.
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (NSString_XMLReader)
+
+-(NSDictionary *) dictionaryFromXML:(NSError**) error;
++(NSDictionary *) dictionaryFromXML:(NSString*) xml error:(NSError**) error;
+
+
+@end

--- a/NSString+XMLReader.h
+++ b/NSString+XMLReader.h
@@ -7,8 +7,8 @@
 
 @interface NSString (NSString_XMLReader)
 
--(NSDictionary *) dictionaryFromXML:(NSError**) error;
-+(NSDictionary *) dictionaryFromXML:(NSString*) xml error:(NSError**) error;
+-(NSDictionary *) dictionaryFromXML:(NSError *__autoreleasing *) error;
++(NSDictionary *) dictionaryFromXML:(NSString*) xml error:(NSError *__autoreleasing *) error;
 
 
 @end

--- a/NSString+XMLReader.m
+++ b/NSString+XMLReader.m
@@ -1,0 +1,21 @@
+//
+//  NSString+XMLReader.m
+//  Created by Fabien Di Tore on 05.08.11.
+
+
+#import "NSString+XMLReader.h"
+#import "XMLReader.h"
+@implementation NSString (NSString_XMLReader)
+
+-(NSDictionary *) dictionaryFromXML:(NSError**) error{
+	return [NSString dictionaryFromXML:self error:error];
+
+}
+
++(NSDictionary *) dictionaryFromXML:(NSString*) xml error:(NSError**) error{
+
+	return [XMLReader dictionaryForXMLString:xml error:error];
+}
+
+
+@end

--- a/NSString+XMLReader.m
+++ b/NSString+XMLReader.m
@@ -7,12 +7,12 @@
 #import "XMLReader.h"
 @implementation NSString (NSString_XMLReader)
 
--(NSDictionary *) dictionaryFromXML:(NSError**) error{
+-(NSDictionary *) dictionaryFromXML:(NSError *__autoreleasing *) error{
 	return [NSString dictionaryFromXML:self error:error];
 
 }
 
-+(NSDictionary *) dictionaryFromXML:(NSString*) xml error:(NSError**) error{
++(NSDictionary *) dictionaryFromXML:(NSString*) xml error:(NSError *__autoreleasing *) error{
 
 	return [XMLReader dictionaryForXMLString:xml error:error];
 }

--- a/XMLQuick.h
+++ b/XMLQuick.h
@@ -1,0 +1,9 @@
+//
+//  XMLQuick.h
+
+//  Created by Fabien Di Tore on 05.08.11.
+
+
+#import "XMLReader.h"
+#import "NSString+XMLReader.h"
+#import "NSData+XMLReader.h"

--- a/XMLReader.h
+++ b/XMLReader.h
@@ -9,12 +9,12 @@
 {
     NSMutableArray *dictionaryStack;
     NSMutableString *textInProgress;
-    NSError **errorPointer;
+    NSError *__autoreleasing *errorPointer;
 }
 
-+ (NSDictionary *)dictionaryForPath:(NSString *)path error:(NSError **)errorPointer;
-+ (NSDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError **)errorPointer;
-+ (NSDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError **)errorPointer;
++ (NSDictionary *)dictionaryForPath:(NSString *)path error:(NSError *__autoreleasing *)errorPointer;
++ (NSDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError *__autoreleasing *)errorPointer;
++ (NSDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError *__autoreleasing *)errorPointer;
 
 @end
 

--- a/XMLReader.h
+++ b/XMLReader.h
@@ -12,9 +12,9 @@
     NSError *__autoreleasing *errorPointer;
 }
 
-+ (NSDictionary *)dictionaryForPath:(NSString *)path error:(NSError *__autoreleasing *)errorPointer;
-+ (NSDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError *__autoreleasing *)errorPointer;
-+ (NSDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError *__autoreleasing *)errorPointer;
++ (NSMutableDictionary *)dictionaryForPath:(NSString *)path error:(NSError *__autoreleasing *)errorPointer;
++ (NSMutableDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError *__autoreleasing *)errorPointer;
++ (NSMutableDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError *__autoreleasing *)errorPointer;
 
 @end
 

--- a/XMLReader.m
+++ b/XMLReader.m
@@ -39,7 +39,7 @@ NSString *const kXMLReaderTextNodeKey = @"text";
             }
             else
             {
-                if ([branch count] > [path intValue])
+                if ([(NSArray *)branch count] > [path intValue])
                 {
                     branch = [branch objectAtIndex:[path intValue]];
                 }

--- a/XMLReader.m
+++ b/XMLReader.m
@@ -9,7 +9,7 @@ NSString *const kXMLReaderTextNodeKey = @"text";
 @interface XMLReader (Internal)
 
 - (id)initWithError:(NSError *__autoreleasing *)error;
-- (NSDictionary *)objectWithData:(NSData *)data;
+- (NSMutableDictionary *)objectWithData:(NSData *)data;
 
 @end
 
@@ -68,23 +68,23 @@ NSString *const kXMLReaderTextNodeKey = @"text";
 #pragma mark -
 #pragma mark Public methods
 
-+ (NSDictionary *)dictionaryForPath:(NSString *)path error:(NSError *__autoreleasing *)errorPointer
++ (NSMutableDictionary *)dictionaryForPath:(NSString *)path error:(NSError *__autoreleasing *)errorPointer
 {
     NSString *fullpath = [[NSBundle bundleForClass:self] pathForResource:path ofType:@"xml"];
 	NSData *data = [[NSFileManager defaultManager] contentsAtPath:fullpath];
-    NSDictionary *rootDictionary = [XMLReader dictionaryForXMLData:data error:errorPointer];
+    NSMutableDictionary *rootDictionary = [XMLReader dictionaryForXMLData:data error:errorPointer];
     
 	return rootDictionary;
 }
 
-+ (NSDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError *__autoreleasing *)error
++ (NSMutableDictionary *)dictionaryForXMLData:(NSData *)data error:(NSError *__autoreleasing *)error
 {
     XMLReader *reader = [[XMLReader alloc] initWithError:error];
-    NSDictionary *rootDictionary = [reader objectWithData:data];    
+    NSMutableDictionary *rootDictionary = [reader objectWithData:data];    
     return rootDictionary;
 }
 
-+ (NSDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError *__autoreleasing *)error
++ (NSMutableDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError *__autoreleasing *)error
 {
 /*    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
     
@@ -115,7 +115,7 @@ NSString *const kXMLReaderTextNodeKey = @"text";
     return self;
 }
 
-- (NSDictionary *)objectWithData:(NSData *)data
+- (NSMutableDictionary *)objectWithData:(NSData *)data
 {
     // Clear out any old data
 
@@ -133,7 +133,7 @@ NSString *const kXMLReaderTextNodeKey = @"text";
     // Return the stack's root dictionary on success
     if (success)
     {
-        NSDictionary *resultDict = [dictionaryStack objectAtIndex:0];
+        NSMutableDictionary *resultDict = [dictionaryStack objectAtIndex:0];
         return resultDict;
     }
     

--- a/XMLReader.m
+++ b/XMLReader.m
@@ -88,8 +88,18 @@ NSString *const kXMLReaderTextNodeKey = @"text";
 
 + (NSDictionary *)dictionaryForXMLString:(NSString *)string error:(NSError **)error
 {
-    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+/*    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
     
+    return [XMLReader dictionaryForXMLData:data error:error];*/
+    NSArray* lines = [string componentsSeparatedByString:@"\n"];
+    NSMutableString* strData = [NSMutableString stringWithString:@""];
+    
+    for (int i = 0; i < [lines count]; i++)
+    {
+        [strData appendString:[[lines objectAtIndex:i] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+    }
+    
+    NSData *data = [strData dataUsingEncoding:NSUTF8StringEncoding];
     return [XMLReader dictionaryForXMLData:data error:error];
 }
 


### PR DESCRIPTION
removing warning since xcode 4.2 and ios 5.0 by casting the variable "branch" in an "NSArray*" when it is one.
